### PR TITLE
Set a newly introduced parameter indicating the password is longer than ...

### DIFF
--- a/korail/korail.py
+++ b/korail/korail.py
@@ -106,6 +106,7 @@ class Korail(object):
             'UserId': id,
             'UserPwd': password,
             'hidMemberFlg': '1',  # 없으면 입력값 오류
+            'txtDv': '1' if len(password) == 4 else '2',
         }
         r = self.session.post(url, data=data)
 


### PR DESCRIPTION
After the recent change of the new password policy for passwords in korail.com, the txtDv field must be set that indicates the length of password is 4 or longer.
